### PR TITLE
Add GetCookieCollection param Uri: url

### DIFF
--- a/ScrapySharp/Network/ScrapingBrowser.cs
+++ b/ScrapySharp/Network/ScrapingBrowser.cs
@@ -459,5 +459,10 @@ namespace ScrapySharp.Network
 
             return collection[name];
         }
+
+        public CookieCollection GetCookieCollection(Uri url)
+        {
+            return cookieContainer.GetCookies(url);
+        }
     }
 }


### PR DESCRIPTION
I propose this method to give the possibility to retrieve from the browser all the cookie collection using the Uri wish in same cases is really helpful, because I think we are not always supposed to know all the cookies name but we would like to use them 
