### PR TITLE
Replaced blocking/synchronous call

### DIFF
--- a/ScrapySharp/Network/ScrapingBrowser.cs
+++ b/ScrapySharp/Network/ScrapingBrowser.cs
@@ -334,7 +334,7 @@ namespace ScrapySharp.Network
 
             if (verb == HttpVerb.Post)
             {
-                var stream = request.GetRequestStream();
+                var stream = await request.GetRequestStreamAsync();
                 using (var writer = new StreamWriter(stream))
                 {
                     writer.Write(data);


### PR DESCRIPTION
This code would block when the concurrent number of connections with requests was exhausted for the servicepoint.