### PR TITLE
Replaced blocking/synchronous call

### DIFF
--- a/ScrapySharp/Network/ScrapingBrowser.cs
+++ b/ScrapySharp/Network/ScrapingBrowser.cs
@@ -370,7 +370,7 @@ namespace ScrapySharp.Network
 
             if (verb == HttpVerb.Post)
             {
-                var stream = request.GetRequestStream();
+                var stream = await request.GetRequestStreamAsync();
                 using (var writer = new StreamWriter(stream))
                 {
                     writer.Write(data);


### PR DESCRIPTION
Replaced another sync request with its async equivalent to avoid blocking under high load. Have been using it for two months now without issues and it fixes the problem well (I use 8-32 concurrent connections on the service endpoint, and it's a GUI app, so blocking is really noticeable)