### PR TITLE
Async Form Submit and Fixed ScrapingBrowser Response

### DIFF
--- a/ScrapySharp/Html/Forms/PageWebForm.cs
+++ b/ScrapySharp/Html/Forms/PageWebForm.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using System.Web;
 using HtmlAgilityPack;
 using ScrapySharp.Network;
@@ -155,6 +156,28 @@ namespace ScrapySharp.Html.Forms
 
             url = browser.Referer.Combine(action);
             return browser.NavigateToPage(url, method, SerializeFormFields());
+        }
+
+        public async Task<WebPage> SubmitAsync(Uri url, HttpVerb verb)
+        {
+            return await browser.NavigateToPageAsync(url, verb, SerializeFormFields());
+        }
+
+        public async Task<WebPage> SubmitAsync(Uri url)
+        {
+            return await browser.NavigateToPageAsync(url, method, SerializeFormFields());
+        }
+
+        public async Task<WebPage> SubmitAsync()
+        {
+            Uri url;
+            if (Uri.TryCreate(Action, UriKind.Absolute, out url))
+            {
+                return await browser.NavigateToPageAsync(url, method, SerializeFormFields());
+            }
+
+            url = browser.Referer.Combine(action);
+            return await browser.NavigateToPageAsync(url, method, SerializeFormFields());
         }
 
         public HttpVerb Method

--- a/ScrapySharp/Network/ScrapingBrowser.cs
+++ b/ScrapySharp/Network/ScrapingBrowser.cs
@@ -269,7 +269,16 @@ namespace ScrapySharp.Network
         {
             referer = url;
             request.AllowAutoRedirect = AllowAutoRedirect;
-            var response = (HttpWebResponse) await request.GetResponseAsync();
+            HttpWebResponse response;
+            try
+            {
+                response = (HttpWebResponse)await request.GetResponseAsync();
+            }
+            catch (WebException e)
+            {
+                response = (HttpWebResponse)e.Response;
+            }
+		
             var headers = response.Headers;
 
             if (!IgnoreCookies)


### PR DESCRIPTION
Added async submit methods to PageWebForm, and allowed GetWebResponseAsync to return a response when a WebException occurs.