### PR TITLE
Added property to ScrapingBrowser to skip certificate validation

### DIFF
--- a/ScrapySharp.Core/ScrapySharp.Core.fsproj
+++ b/ScrapySharp.Core/ScrapySharp.Core.fsproj
@@ -3,8 +3,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.7.*" />
-    <PackageReference Include="FSharp.Core" Version="4.*" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.42" />
+    <PackageReference Include="FSharp.Core" Version="5.0.2" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Models.fs" />

--- a/ScrapySharp.Tests/ScrapySharp.Tests.csproj
+++ b/ScrapySharp.Tests/ScrapySharp.Tests.csproj
@@ -3,11 +3,11 @@
     <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.7.*" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
-    <PackageReference Include="System.Runtime.Caching" Version="4.5.0-preview1-26216-02" />
-    <PackageReference Include="NUnit" Version="3.10.*" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.42" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="System.Runtime.Caching" Version="5.0.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ScrapySharp.Core\ScrapySharp.Core.fsproj" />

--- a/ScrapySharp.Tests/When_use_browser.cs
+++ b/ScrapySharp.Tests/When_use_browser.cs
@@ -67,6 +67,27 @@ namespace ScrapySharp.Tests
 
             Assert.AreNotEqual(html1, html2);
         }
-        
+
+        [Test]
+        public void When_skipping_certificate_validation()
+        {
+            var uri = new Uri("https://expired.badssl.com/");
+
+            var browser1 = new ScrapingBrowser {
+                SkipCertificateValidation = false };
+
+            var hasException = false;
+            try { browser1.NavigateToPage(uri); }
+            catch (Exception) { hasException = true; }
+
+            Assert.IsTrue(hasException);
+
+            var browser2 = new ScrapingBrowser() {
+                SkipCertificateValidation = true };
+
+            var page2 = browser2.NavigateToPage(uri);
+
+            Assert.AreEqual(200, page2.RawResponse.StatusCode);
+        }
     }
 }

--- a/ScrapySharp.sln
+++ b/ScrapySharp.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31205.134
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{6755677C-979E-4D67-A21F-FAAF7598A993}"
 	ProjectSection(SolutionItems) = preProject
@@ -10,40 +10,16 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		ReleaseNotes.txt = ReleaseNotes.txt
 		ScrapySharp.nuspec = ScrapySharp.nuspec
 	EndProjectSection
-	GlobalSection(HgVSProperties) = preSolution
-		SolutionIsControlled = True
-		SolutionBindings = <Solution Location In Database>
-	EndGlobalSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ScrapySharp", "ScrapySharp\ScrapySharp.csproj", "{19858AEA-E842-4633-AF1B-110ED4FE3770}"
-	GlobalSection(HgVSProperties) = preSolution
-		SolutionIsControlled = True
-		SolutionBindings = <Solution Location In Database>
-	EndGlobalSection
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ScrapySharp", "ScrapySharp\ScrapySharp.csproj", "{19858AEA-E842-4633-AF1B-110ED4FE3770}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ScrapySharp.Tests", "ScrapySharp.Tests\ScrapySharp.Tests.csproj", "{99F509FE-B51C-48A8-8C79-DD32AD2FDF10}"
-	GlobalSection(HgVSProperties) = preSolution
-		SolutionIsControlled = True
-		SolutionBindings = <Solution Location In Database>
-	EndGlobalSection
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ScrapySharp.Tests", "ScrapySharp.Tests\ScrapySharp.Tests.csproj", "{99F509FE-B51C-48A8-8C79-DD32AD2FDF10}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "ScrapySharp.Core", "ScrapySharp.Core\ScrapySharp.Core.fsproj", "{CE27016B-2755-4B44-8A0E-574914B9256F}"
-	GlobalSection(HgVSProperties) = preSolution
-		SolutionIsControlled = True
-		SolutionBindings = <Solution Location In Database>
-	EndGlobalSection
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "ScrapySharp.Core", "ScrapySharp.Core\ScrapySharp.Core.fsproj", "{CE27016B-2755-4B44-8A0E-574914B9256F}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Libraries", "Libraries", "{F0E92760-C697-4CC6-8767-8929C6C9898E}"
-	GlobalSection(HgVSProperties) = preSolution
-		SolutionIsControlled = True
-		SolutionBindings = <Solution Location In Database>
-	EndGlobalSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{D5D992B5-D7B1-4132-A8E1-078513363057}"
-	GlobalSection(HgVSProperties) = preSolution
-		SolutionIsControlled = True
-		SolutionBindings = <Solution Location In Database>
-	EndGlobalSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -101,6 +77,33 @@ Global
 		{19858AEA-E842-4633-AF1B-110ED4FE3770} = {F0E92760-C697-4CC6-8767-8929C6C9898E}
 		{99F509FE-B51C-48A8-8C79-DD32AD2FDF10} = {D5D992B5-D7B1-4132-A8E1-078513363057}
 		{CE27016B-2755-4B44-8A0E-574914B9256F} = {F0E92760-C697-4CC6-8767-8929C6C9898E}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {3205FC55-E7BE-4700-A812-9B2E39AE8E1B}
+	EndGlobalSection
+	GlobalSection(HgVSProperties) = preSolution
+		SolutionIsControlled = True
+		SolutionBindings = <Solution Location In Database>
+	EndGlobalSection
+	GlobalSection(HgVSProperties) = preSolution
+		SolutionIsControlled = True
+		SolutionBindings = <Solution Location In Database>
+	EndGlobalSection
+	GlobalSection(HgVSProperties) = preSolution
+		SolutionIsControlled = True
+		SolutionBindings = <Solution Location In Database>
+	EndGlobalSection
+	GlobalSection(HgVSProperties) = preSolution
+		SolutionIsControlled = True
+		SolutionBindings = <Solution Location In Database>
+	EndGlobalSection
+	GlobalSection(HgVSProperties) = preSolution
+		SolutionIsControlled = True
+		SolutionBindings = <Solution Location In Database>
+	EndGlobalSection
+	GlobalSection(HgVSProperties) = preSolution
+		SolutionIsControlled = True
+		SolutionBindings = <Solution Location In Database>
 	EndGlobalSection
 	GlobalSection(HgVSProperties) = preSolution
 		SolutionIsControlled = True

--- a/ScrapySharp/Network/ScrapingBrowser.cs
+++ b/ScrapySharp/Network/ScrapingBrowser.cs
@@ -179,13 +179,19 @@ namespace ScrapySharp.Network
         private async Task<WebPage> GetResponseAsync(Uri url, HttpWebRequest request, int iteration, byte[] requestBody)
         {
             var response = await GetWebResponseAsync(url, request);
-            var responseStream = response.GetResponseStream();
+            var responseStream = response?.GetResponseStream();
             var headers = request.Headers.AllKeys.Select(k => new KeyValuePair<string, string>(k, request.Headers[k])).ToList();
 
             if (responseStream == null)
+            {
+                var rawResponse = response != null
+                    ? new RawResponse(response.ProtocolVersion, response.StatusCode, response.StatusDescription, response.Headers, new byte[0], Encoding)
+                    : new RawResponse(request.ProtocolVersion, HttpStatusCode.BadRequest, "", new NameValueCollection(), new byte[0], Encoding);
+
                 return new WebPage(this, url, AutoDownloadPagesResources,
                     new RawRequest(request.Method, request.RequestUri, request.ProtocolVersion, headers, requestBody, Encoding),
-                    new RawResponse(response.ProtocolVersion, response.StatusCode, response.StatusDescription, response.Headers, new byte[0], Encoding), Encoding, AutoDetectCharsetEncoding);
+                    rawResponse, Encoding, AutoDetectCharsetEncoding);
+            }
 
             var body = new MemoryStream();
             responseStream.CopyTo(body);
@@ -282,12 +288,10 @@ namespace ScrapySharp.Network
             {
                 response = (HttpWebResponse)e.Response;
             }
-		
-            var headers = response.Headers;
 
             if (!IgnoreCookies)
             {
-                var cookiesExpression = headers["Set-Cookie"];
+                var cookiesExpression = response?.Headers["Set-Cookie"];
                 if (!string.IsNullOrEmpty(cookiesExpression))
                 {
                     var cookieUrl =

--- a/ScrapySharp/Network/ScrapingBrowser.cs
+++ b/ScrapySharp/Network/ScrapingBrowser.cs
@@ -30,6 +30,7 @@ namespace ScrapySharp.Network
             Language = CultureInfo.CreateSpecificCulture("EN-US");
             UseDefaultCookiesParser = true;
             IgnoreCookies = false;
+            SkipCertificateValidation = false;
             ProtocolVersion = HttpVersion.Version10;
             KeepAlive = false;
             Proxy = WebRequest.DefaultWebProxy;
@@ -158,6 +159,9 @@ namespace ScrapySharp.Network
             }
             else
                 request.SendChunked = SendChunked;
+
+            if (SkipCertificateValidation)
+                request.ServerCertificateValidationCallback = delegate { return true; };
 
             return request;
         }
@@ -448,6 +452,8 @@ namespace ScrapySharp.Network
         public bool UseDefaultCookiesParser { get; set; }
 
         public bool IgnoreCookies { get; set; }
+
+        public bool SkipCertificateValidation { get; set; }
 
         public TimeSpan Timeout { get; set; }
 

--- a/ScrapySharp/ScrapySharp.csproj
+++ b/ScrapySharp/ScrapySharp.csproj
@@ -22,12 +22,12 @@
     <RepositoryUrl>https://github.com/rflechner/ScrapySharp.git</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.7.*" />
-    <PackageReference Include="FSharp.Core" Version="4.*" />
-    <PackageReference Include="System.Runtime.Caching" Version="4.5.0-preview1-26216-02" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.42" />
+    <PackageReference Include="FSharp.Core" Version="5.0.2" />
+    <PackageReference Include="System.Runtime.Caching" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\ScrapySharp.Core\ScrapySharp.Core.fsproj" PrivateAssets="All"/>
+    <ProjectReference Include="..\ScrapySharp.Core\ScrapySharp.Core.fsproj" PrivateAssets="All" />
   </ItemGroup>
   <Target Name="IncludeP2PAssets">
     <ItemGroup>


### PR DESCRIPTION
ScrapingBrowser throws an exception if there is a problem with the server certificate. This exception prevents you from downloading the actual page and its content. I thought it might be useful to make this behavior configurable.

This fix allows to skip the server certificate validation and to download pages from domains with invalid certificates.